### PR TITLE
Raise EAPI 5 ebuilds level to EAPI 7 to prevent unsupported EAPI warn…

### DIFF
--- a/app-office/qownnotes/qownnotes-1.1.0.4-r1.ebuild
+++ b/app-office/qownnotes/qownnotes-1.1.0.4-r1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 1.1.0.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -37,6 +37,7 @@ src_prepare() {
 	cd src
 	echo "#define VERSION \"1.1.0.4\"" > version.h
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 
 	cd libraries
 	rmdir qmarkdowntextedit piwikitracker

--- a/app-office/qownnotes/qownnotes-1.2.0-r1.ebuild
+++ b/app-office/qownnotes/qownnotes-1.2.0-r1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 1.2.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -56,6 +56,7 @@ src_prepare() {
 	cd src
 	echo "#define VERSION \"1.2.0\"" > version.h
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-1.3.0-r1.ebuild
+++ b/app-office/qownnotes/qownnotes-1.3.0-r1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 1.3.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -56,6 +56,7 @@ src_prepare() {
 	cd src
 	echo "#define VERSION \"1.3.0\"" > version.h
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-1.4.0-r1.ebuild
+++ b/app-office/qownnotes/qownnotes-1.4.0-r1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 1.4.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -56,6 +56,7 @@ src_prepare() {
 	cd src
 	echo "#define VERSION \"1.4.0\"" > version.h
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-16.04.12-r1.ebuild
+++ b/app-office/qownnotes/qownnotes-16.04.12-r1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 16.04.12
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -56,6 +56,7 @@ src_prepare() {
 	cd src
 	echo "#define VERSION \"16.04.12\"" > version.h
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-16.05.0-r1.ebuild
+++ b/app-office/qownnotes/qownnotes-16.05.0-r1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 16.05.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -56,6 +56,7 @@ src_prepare() {
 	cd src
 	echo "#define VERSION \"16.05.0\"" > version.h
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-16.06.0-r1.ebuild
+++ b/app-office/qownnotes/qownnotes-16.06.0-r1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 16.06.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -34,6 +34,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-16.07.0-r1.ebuild
+++ b/app-office/qownnotes/qownnotes-16.07.0-r1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 16.07.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -34,6 +34,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-16.08.0-r1.ebuild
+++ b/app-office/qownnotes/qownnotes-16.08.0-r1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 16.08.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -34,6 +34,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-16.09.0-r1.ebuild
+++ b/app-office/qownnotes/qownnotes-16.09.0-r1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 16.09.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-16.10.0-r1.ebuild
+++ b/app-office/qownnotes/qownnotes-16.10.0-r1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 16.10.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-16.11.0-r1.ebuild
+++ b/app-office/qownnotes/qownnotes-16.11.0-r1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 16.11.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-16.11.17.ebuild
+++ b/app-office/qownnotes/qownnotes-16.11.17.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 16.11.17
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-16.11.18.ebuild
+++ b/app-office/qownnotes/qownnotes-16.11.18.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 16.11.18
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-16.12.0.ebuild
+++ b/app-office/qownnotes/qownnotes-16.12.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 16.12.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-16.12.1.ebuild
+++ b/app-office/qownnotes/qownnotes-16.12.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 16.12.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-16.12.10.ebuild
+++ b/app-office/qownnotes/qownnotes-16.12.10.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 16.12.10
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-16.12.11.ebuild
+++ b/app-office/qownnotes/qownnotes-16.12.11.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 16.12.11
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-16.12.12.ebuild
+++ b/app-office/qownnotes/qownnotes-16.12.12.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 16.12.12
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-16.12.13.ebuild
+++ b/app-office/qownnotes/qownnotes-16.12.13.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 16.12.13
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-16.12.14.ebuild
+++ b/app-office/qownnotes/qownnotes-16.12.14.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 16.12.14
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-16.12.15.ebuild
+++ b/app-office/qownnotes/qownnotes-16.12.15.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 16.12.15
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-16.12.16.ebuild
+++ b/app-office/qownnotes/qownnotes-16.12.16.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 16.12.16
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-16.12.2.ebuild
+++ b/app-office/qownnotes/qownnotes-16.12.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 16.12.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-16.12.3.ebuild
+++ b/app-office/qownnotes/qownnotes-16.12.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 16.12.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-16.12.4.ebuild
+++ b/app-office/qownnotes/qownnotes-16.12.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 16.12.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-16.12.5.ebuild
+++ b/app-office/qownnotes/qownnotes-16.12.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 16.12.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-16.12.6.ebuild
+++ b/app-office/qownnotes/qownnotes-16.12.6.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 16.12.6
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-16.12.7.ebuild
+++ b/app-office/qownnotes/qownnotes-16.12.7.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 16.12.7
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-16.12.8.ebuild
+++ b/app-office/qownnotes/qownnotes-16.12.8.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 16.12.8
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-16.12.9.ebuild
+++ b/app-office/qownnotes/qownnotes-16.12.9.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 16.12.9
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.01.0.ebuild
+++ b/app-office/qownnotes/qownnotes-17.01.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.01.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.01.1.ebuild
+++ b/app-office/qownnotes/qownnotes-17.01.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.01.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.01.10.ebuild
+++ b/app-office/qownnotes/qownnotes-17.01.10.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.01.10
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.01.11.ebuild
+++ b/app-office/qownnotes/qownnotes-17.01.11.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.01.11
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.01.12.ebuild
+++ b/app-office/qownnotes/qownnotes-17.01.12.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.01.12
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.01.13.ebuild
+++ b/app-office/qownnotes/qownnotes-17.01.13.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.01.13
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.01.14.ebuild
+++ b/app-office/qownnotes/qownnotes-17.01.14.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.01.14
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.01.2.ebuild
+++ b/app-office/qownnotes/qownnotes-17.01.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.01.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.01.3.ebuild
+++ b/app-office/qownnotes/qownnotes-17.01.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.01.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.01.4.ebuild
+++ b/app-office/qownnotes/qownnotes-17.01.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.01.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.01.5.ebuild
+++ b/app-office/qownnotes/qownnotes-17.01.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.01.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.01.6.ebuild
+++ b/app-office/qownnotes/qownnotes-17.01.6.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.01.6
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.01.7.ebuild
+++ b/app-office/qownnotes/qownnotes-17.01.7.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.01.7
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.01.8.ebuild
+++ b/app-office/qownnotes/qownnotes-17.01.8.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.01.8
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.01.9.ebuild
+++ b/app-office/qownnotes/qownnotes-17.01.9.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.01.9
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.02.0.ebuild
+++ b/app-office/qownnotes/qownnotes-17.02.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.02.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.02.1.ebuild
+++ b/app-office/qownnotes/qownnotes-17.02.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.02.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.02.2.ebuild
+++ b/app-office/qownnotes/qownnotes-17.02.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.02.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.02.3.ebuild
+++ b/app-office/qownnotes/qownnotes-17.02.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.02.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.02.4.ebuild
+++ b/app-office/qownnotes/qownnotes-17.02.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.02.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.02.5.ebuild
+++ b/app-office/qownnotes/qownnotes-17.02.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.02.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.02.6.ebuild
+++ b/app-office/qownnotes/qownnotes-17.02.6.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.02.6
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.03.0.ebuild
+++ b/app-office/qownnotes/qownnotes-17.03.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.03.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.03.1.ebuild
+++ b/app-office/qownnotes/qownnotes-17.03.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.03.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.03.2.ebuild
+++ b/app-office/qownnotes/qownnotes-17.03.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.03.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.03.3.ebuild
+++ b/app-office/qownnotes/qownnotes-17.03.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.03.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.03.4.ebuild
+++ b/app-office/qownnotes/qownnotes-17.03.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.03.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.03.5.ebuild
+++ b/app-office/qownnotes/qownnotes-17.03.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.03.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.03.6.ebuild
+++ b/app-office/qownnotes/qownnotes-17.03.6.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.03.6
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.03.7.ebuild
+++ b/app-office/qownnotes/qownnotes-17.03.7.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.03.7
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.03.8.ebuild
+++ b/app-office/qownnotes/qownnotes-17.03.8.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.03.8
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.03.9.ebuild
+++ b/app-office/qownnotes/qownnotes-17.03.9.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.03.9
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.04.0.ebuild
+++ b/app-office/qownnotes/qownnotes-17.04.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.04.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.04.1.ebuild
+++ b/app-office/qownnotes/qownnotes-17.04.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.04.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.04.2.ebuild
+++ b/app-office/qownnotes/qownnotes-17.04.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.04.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.04.3.ebuild
+++ b/app-office/qownnotes/qownnotes-17.04.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.04.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.04.4.ebuild
+++ b/app-office/qownnotes/qownnotes-17.04.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.04.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.05.0.ebuild
+++ b/app-office/qownnotes/qownnotes-17.05.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.05.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.05.1.ebuild
+++ b/app-office/qownnotes/qownnotes-17.05.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.05.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.05.10.ebuild
+++ b/app-office/qownnotes/qownnotes-17.05.10.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.05.10
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.05.11.ebuild
+++ b/app-office/qownnotes/qownnotes-17.05.11.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.05.11
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.05.12.ebuild
+++ b/app-office/qownnotes/qownnotes-17.05.12.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.05.12
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.05.13.ebuild
+++ b/app-office/qownnotes/qownnotes-17.05.13.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.05.13
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.05.14.ebuild
+++ b/app-office/qownnotes/qownnotes-17.05.14.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.05.14
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.05.2.ebuild
+++ b/app-office/qownnotes/qownnotes-17.05.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.05.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.05.3.ebuild
+++ b/app-office/qownnotes/qownnotes-17.05.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.05.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.05.4.ebuild
+++ b/app-office/qownnotes/qownnotes-17.05.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.05.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.05.5.ebuild
+++ b/app-office/qownnotes/qownnotes-17.05.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.05.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.05.6.ebuild
+++ b/app-office/qownnotes/qownnotes-17.05.6.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.05.6
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.05.7.ebuild
+++ b/app-office/qownnotes/qownnotes-17.05.7.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.05.7
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.05.8.ebuild
+++ b/app-office/qownnotes/qownnotes-17.05.8.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.05.8
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.05.9.ebuild
+++ b/app-office/qownnotes/qownnotes-17.05.9.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.05.9
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.06.0.ebuild
+++ b/app-office/qownnotes/qownnotes-17.06.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.06.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.06.1.ebuild
+++ b/app-office/qownnotes/qownnotes-17.06.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.06.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.06.2.ebuild
+++ b/app-office/qownnotes/qownnotes-17.06.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.06.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.06.3.ebuild
+++ b/app-office/qownnotes/qownnotes-17.06.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.06.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.06.4.ebuild
+++ b/app-office/qownnotes/qownnotes-17.06.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.06.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.06.5.ebuild
+++ b/app-office/qownnotes/qownnotes-17.06.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.06.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.06.6.ebuild
+++ b/app-office/qownnotes/qownnotes-17.06.6.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.06.6
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.07.0.ebuild
+++ b/app-office/qownnotes/qownnotes-17.07.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.07.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.07.1.ebuild
+++ b/app-office/qownnotes/qownnotes-17.07.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.07.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.07.2.ebuild
+++ b/app-office/qownnotes/qownnotes-17.07.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.07.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.07.3.ebuild
+++ b/app-office/qownnotes/qownnotes-17.07.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.07.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.07.4.ebuild
+++ b/app-office/qownnotes/qownnotes-17.07.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.07.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.07.5.ebuild
+++ b/app-office/qownnotes/qownnotes-17.07.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.07.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.07.6.ebuild
+++ b/app-office/qownnotes/qownnotes-17.07.6.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.07.6
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.07.7.ebuild
+++ b/app-office/qownnotes/qownnotes-17.07.7.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.07.7
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.07.8.ebuild
+++ b/app-office/qownnotes/qownnotes-17.07.8.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.07.8
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.07.9.ebuild
+++ b/app-office/qownnotes/qownnotes-17.07.9.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.07.9
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.08.0.ebuild
+++ b/app-office/qownnotes/qownnotes-17.08.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.08.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.08.1.ebuild
+++ b/app-office/qownnotes/qownnotes-17.08.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.08.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.08.10.ebuild
+++ b/app-office/qownnotes/qownnotes-17.08.10.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.08.10
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.08.11.ebuild
+++ b/app-office/qownnotes/qownnotes-17.08.11.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.08.11
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.08.2.ebuild
+++ b/app-office/qownnotes/qownnotes-17.08.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.08.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.08.3.ebuild
+++ b/app-office/qownnotes/qownnotes-17.08.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.08.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.08.4.ebuild
+++ b/app-office/qownnotes/qownnotes-17.08.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.08.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.08.5.ebuild
+++ b/app-office/qownnotes/qownnotes-17.08.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.08.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.08.6.ebuild
+++ b/app-office/qownnotes/qownnotes-17.08.6.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.08.6
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.08.7.ebuild
+++ b/app-office/qownnotes/qownnotes-17.08.7.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.08.7
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.08.8.ebuild
+++ b/app-office/qownnotes/qownnotes-17.08.8.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.08.8
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.08.9.ebuild
+++ b/app-office/qownnotes/qownnotes-17.08.9.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.08.9
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.09.0.ebuild
+++ b/app-office/qownnotes/qownnotes-17.09.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.09.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.09.1.ebuild
+++ b/app-office/qownnotes/qownnotes-17.09.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.09.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.09.2.ebuild
+++ b/app-office/qownnotes/qownnotes-17.09.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.09.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.09.3.ebuild
+++ b/app-office/qownnotes/qownnotes-17.09.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.09.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.09.4.ebuild
+++ b/app-office/qownnotes/qownnotes-17.09.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.09.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.09.5.ebuild
+++ b/app-office/qownnotes/qownnotes-17.09.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.09.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.09.6.ebuild
+++ b/app-office/qownnotes/qownnotes-17.09.6.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.09.6
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.09.7.ebuild
+++ b/app-office/qownnotes/qownnotes-17.09.7.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.09.7
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.09.8.ebuild
+++ b/app-office/qownnotes/qownnotes-17.09.8.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.09.8
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.09.9.ebuild
+++ b/app-office/qownnotes/qownnotes-17.09.9.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.09.9
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.10.0.ebuild
+++ b/app-office/qownnotes/qownnotes-17.10.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.10.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.10.1.ebuild
+++ b/app-office/qownnotes/qownnotes-17.10.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.10.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.10.10.ebuild
+++ b/app-office/qownnotes/qownnotes-17.10.10.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.10.10
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.10.2.ebuild
+++ b/app-office/qownnotes/qownnotes-17.10.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.10.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.10.3.ebuild
+++ b/app-office/qownnotes/qownnotes-17.10.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.10.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.10.4.ebuild
+++ b/app-office/qownnotes/qownnotes-17.10.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.10.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.10.5.ebuild
+++ b/app-office/qownnotes/qownnotes-17.10.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.10.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.10.6.ebuild
+++ b/app-office/qownnotes/qownnotes-17.10.6.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.10.6
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.10.7.ebuild
+++ b/app-office/qownnotes/qownnotes-17.10.7.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.10.7
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.10.8.ebuild
+++ b/app-office/qownnotes/qownnotes-17.10.8.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.10.8
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.10.9.ebuild
+++ b/app-office/qownnotes/qownnotes-17.10.9.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.10.9
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.11.0.ebuild
+++ b/app-office/qownnotes/qownnotes-17.11.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.11.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.11.1.ebuild
+++ b/app-office/qownnotes/qownnotes-17.11.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.11.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.11.2.ebuild
+++ b/app-office/qownnotes/qownnotes-17.11.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.11.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.11.3.ebuild
+++ b/app-office/qownnotes/qownnotes-17.11.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.11.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.11.4.ebuild
+++ b/app-office/qownnotes/qownnotes-17.11.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.11.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.11.5.ebuild
+++ b/app-office/qownnotes/qownnotes-17.11.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.11.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.11.6.ebuild
+++ b/app-office/qownnotes/qownnotes-17.11.6.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.11.6
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.12.0.ebuild
+++ b/app-office/qownnotes/qownnotes-17.12.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.12.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.12.1.ebuild
+++ b/app-office/qownnotes/qownnotes-17.12.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.12.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.12.2.ebuild
+++ b/app-office/qownnotes/qownnotes-17.12.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.12.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.12.3.ebuild
+++ b/app-office/qownnotes/qownnotes-17.12.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.12.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.12.4.ebuild
+++ b/app-office/qownnotes/qownnotes-17.12.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.12.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.12.5.ebuild
+++ b/app-office/qownnotes/qownnotes-17.12.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.12.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-17.12.6.ebuild
+++ b/app-office/qownnotes/qownnotes-17.12.6.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 17.12.6
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.01.0.ebuild
+++ b/app-office/qownnotes/qownnotes-18.01.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.01.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.01.1.ebuild
+++ b/app-office/qownnotes/qownnotes-18.01.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.01.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.01.2.ebuild
+++ b/app-office/qownnotes/qownnotes-18.01.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.01.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.01.3.ebuild
+++ b/app-office/qownnotes/qownnotes-18.01.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.01.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.01.4.ebuild
+++ b/app-office/qownnotes/qownnotes-18.01.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.01.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.02.0.ebuild
+++ b/app-office/qownnotes/qownnotes-18.02.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.02.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.02.1.ebuild
+++ b/app-office/qownnotes/qownnotes-18.02.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.02.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.02.2.ebuild
+++ b/app-office/qownnotes/qownnotes-18.02.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.02.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.02.3.ebuild
+++ b/app-office/qownnotes/qownnotes-18.02.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.02.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.02.4.ebuild
+++ b/app-office/qownnotes/qownnotes-18.02.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.02.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.02.5.ebuild
+++ b/app-office/qownnotes/qownnotes-18.02.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.02.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.03.0.ebuild
+++ b/app-office/qownnotes/qownnotes-18.03.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.03.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.03.1.1.ebuild
+++ b/app-office/qownnotes/qownnotes-18.03.1.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.03.1.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.03.10.ebuild
+++ b/app-office/qownnotes/qownnotes-18.03.10.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.03.10
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.03.2.ebuild
+++ b/app-office/qownnotes/qownnotes-18.03.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.03.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.03.3.ebuild
+++ b/app-office/qownnotes/qownnotes-18.03.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.03.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.03.4.ebuild
+++ b/app-office/qownnotes/qownnotes-18.03.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.03.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.03.5.ebuild
+++ b/app-office/qownnotes/qownnotes-18.03.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.03.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.03.6.ebuild
+++ b/app-office/qownnotes/qownnotes-18.03.6.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.03.6
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.03.7.ebuild
+++ b/app-office/qownnotes/qownnotes-18.03.7.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.03.7
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.03.8.ebuild
+++ b/app-office/qownnotes/qownnotes-18.03.8.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.03.8
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.03.9.ebuild
+++ b/app-office/qownnotes/qownnotes-18.03.9.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.03.9
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.04.0.ebuild
+++ b/app-office/qownnotes/qownnotes-18.04.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.04.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.04.1.ebuild
+++ b/app-office/qownnotes/qownnotes-18.04.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.04.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.04.2.ebuild
+++ b/app-office/qownnotes/qownnotes-18.04.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.04.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.04.3.ebuild
+++ b/app-office/qownnotes/qownnotes-18.04.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.04.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.04.4.ebuild
+++ b/app-office/qownnotes/qownnotes-18.04.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.04.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.04.5.ebuild
+++ b/app-office/qownnotes/qownnotes-18.04.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.04.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.05.0.ebuild
+++ b/app-office/qownnotes/qownnotes-18.05.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.05.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.05.1.ebuild
+++ b/app-office/qownnotes/qownnotes-18.05.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.05.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.05.2.ebuild
+++ b/app-office/qownnotes/qownnotes-18.05.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.05.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.05.3.ebuild
+++ b/app-office/qownnotes/qownnotes-18.05.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.05.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.05.4.ebuild
+++ b/app-office/qownnotes/qownnotes-18.05.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.05.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.05.5.ebuild
+++ b/app-office/qownnotes/qownnotes-18.05.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.05.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.05.6.ebuild
+++ b/app-office/qownnotes/qownnotes-18.05.6.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.05.6
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.05.7.ebuild
+++ b/app-office/qownnotes/qownnotes-18.05.7.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.05.7
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.06.0.ebuild
+++ b/app-office/qownnotes/qownnotes-18.06.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.06.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.06.1.ebuild
+++ b/app-office/qownnotes/qownnotes-18.06.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.06.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.06.2.ebuild
+++ b/app-office/qownnotes/qownnotes-18.06.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.06.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.06.3.ebuild
+++ b/app-office/qownnotes/qownnotes-18.06.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.06.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.06.4.ebuild
+++ b/app-office/qownnotes/qownnotes-18.06.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.06.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.06.5.ebuild
+++ b/app-office/qownnotes/qownnotes-18.06.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.06.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.06.6.ebuild
+++ b/app-office/qownnotes/qownnotes-18.06.6.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.06.6
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.06.7.ebuild
+++ b/app-office/qownnotes/qownnotes-18.06.7.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.06.7
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.07.0.ebuild
+++ b/app-office/qownnotes/qownnotes-18.07.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.07.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.07.2.ebuild
+++ b/app-office/qownnotes/qownnotes-18.07.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.07.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.07.3.ebuild
+++ b/app-office/qownnotes/qownnotes-18.07.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.07.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.07.4.ebuild
+++ b/app-office/qownnotes/qownnotes-18.07.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.07.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.07.5.ebuild
+++ b/app-office/qownnotes/qownnotes-18.07.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.07.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.07.6.ebuild
+++ b/app-office/qownnotes/qownnotes-18.07.6.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.07.6
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.07.7.ebuild
+++ b/app-office/qownnotes/qownnotes-18.07.7.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.07.7
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.07.8.ebuild
+++ b/app-office/qownnotes/qownnotes-18.07.8.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.07.8
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.08.0.ebuild
+++ b/app-office/qownnotes/qownnotes-18.08.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.08.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.08.1.ebuild
+++ b/app-office/qownnotes/qownnotes-18.08.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.08.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.08.10.ebuild
+++ b/app-office/qownnotes/qownnotes-18.08.10.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.08.10
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.08.11.ebuild
+++ b/app-office/qownnotes/qownnotes-18.08.11.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.08.11
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.08.2.ebuild
+++ b/app-office/qownnotes/qownnotes-18.08.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.08.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.08.3.ebuild
+++ b/app-office/qownnotes/qownnotes-18.08.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.08.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.08.4.ebuild
+++ b/app-office/qownnotes/qownnotes-18.08.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.08.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.08.5.1.ebuild
+++ b/app-office/qownnotes/qownnotes-18.08.5.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.08.5.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.08.5.ebuild
+++ b/app-office/qownnotes/qownnotes-18.08.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.08.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.08.6.ebuild
+++ b/app-office/qownnotes/qownnotes-18.08.6.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.08.6
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.08.7.ebuild
+++ b/app-office/qownnotes/qownnotes-18.08.7.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.08.7
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.08.8.ebuild
+++ b/app-office/qownnotes/qownnotes-18.08.8.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.08.8
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.08.9.ebuild
+++ b/app-office/qownnotes/qownnotes-18.08.9.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.08.9
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.09.0.ebuild
+++ b/app-office/qownnotes/qownnotes-18.09.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.09.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.09.1.ebuild
+++ b/app-office/qownnotes/qownnotes-18.09.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.09.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.09.2.ebuild
+++ b/app-office/qownnotes/qownnotes-18.09.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.09.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.09.3.ebuild
+++ b/app-office/qownnotes/qownnotes-18.09.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.09.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.09.4.ebuild
+++ b/app-office/qownnotes/qownnotes-18.09.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.09.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.09.5.ebuild
+++ b/app-office/qownnotes/qownnotes-18.09.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.09.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.10.0.ebuild
+++ b/app-office/qownnotes/qownnotes-18.10.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.10.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.10.1.ebuild
+++ b/app-office/qownnotes/qownnotes-18.10.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.10.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.10.2.ebuild
+++ b/app-office/qownnotes/qownnotes-18.10.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.10.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.10.3.ebuild
+++ b/app-office/qownnotes/qownnotes-18.10.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.10.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.10.4.ebuild
+++ b/app-office/qownnotes/qownnotes-18.10.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.10.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.10.5.ebuild
+++ b/app-office/qownnotes/qownnotes-18.10.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.10.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.10.6.ebuild
+++ b/app-office/qownnotes/qownnotes-18.10.6.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.10.6
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.11.0.ebuild
+++ b/app-office/qownnotes/qownnotes-18.11.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.11.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.11.1.ebuild
+++ b/app-office/qownnotes/qownnotes-18.11.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.11.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.11.2.ebuild
+++ b/app-office/qownnotes/qownnotes-18.11.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.11.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.11.3.ebuild
+++ b/app-office/qownnotes/qownnotes-18.11.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.11.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.11.4.ebuild
+++ b/app-office/qownnotes/qownnotes-18.11.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.11.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.11.5.ebuild
+++ b/app-office/qownnotes/qownnotes-18.11.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.11.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.11.6.ebuild
+++ b/app-office/qownnotes/qownnotes-18.11.6.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.11.6
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.12.0.ebuild
+++ b/app-office/qownnotes/qownnotes-18.12.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.12.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.12.1.ebuild
+++ b/app-office/qownnotes/qownnotes-18.12.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.12.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.12.2.ebuild
+++ b/app-office/qownnotes/qownnotes-18.12.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.12.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.12.3.ebuild
+++ b/app-office/qownnotes/qownnotes-18.12.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.12.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.12.4.ebuild
+++ b/app-office/qownnotes/qownnotes-18.12.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.12.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.12.5.ebuild
+++ b/app-office/qownnotes/qownnotes-18.12.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.12.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -35,6 +35,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.12.6.ebuild
+++ b/app-office/qownnotes/qownnotes-18.12.6.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.12.6
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.12.7.ebuild
+++ b/app-office/qownnotes/qownnotes-18.12.7.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.12.7
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.12.8.ebuild
+++ b/app-office/qownnotes/qownnotes-18.12.8.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.12.8
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-18.12.9.ebuild
+++ b/app-office/qownnotes/qownnotes-18.12.9.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 18.12.9
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.1.0.ebuild
+++ b/app-office/qownnotes/qownnotes-19.1.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.1.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.1.1.ebuild
+++ b/app-office/qownnotes/qownnotes-19.1.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.1.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.1.10.ebuild
+++ b/app-office/qownnotes/qownnotes-19.1.10.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.1.10
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.1.11.ebuild
+++ b/app-office/qownnotes/qownnotes-19.1.11.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.1.11
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.1.2.ebuild
+++ b/app-office/qownnotes/qownnotes-19.1.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.1.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.1.3.ebuild
+++ b/app-office/qownnotes/qownnotes-19.1.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.1.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.1.4.ebuild
+++ b/app-office/qownnotes/qownnotes-19.1.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.1.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.1.5.ebuild
+++ b/app-office/qownnotes/qownnotes-19.1.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.1.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.1.6.ebuild
+++ b/app-office/qownnotes/qownnotes-19.1.6.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.1.6
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.1.7.ebuild
+++ b/app-office/qownnotes/qownnotes-19.1.7.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.1.7
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.1.8.ebuild
+++ b/app-office/qownnotes/qownnotes-19.1.8.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.1.8
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.1.9.ebuild
+++ b/app-office/qownnotes/qownnotes-19.1.9.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.1.9
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.10.0.ebuild
+++ b/app-office/qownnotes/qownnotes-19.10.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.10.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.10.1.ebuild
+++ b/app-office/qownnotes/qownnotes-19.10.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.10.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.10.10.ebuild
+++ b/app-office/qownnotes/qownnotes-19.10.10.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.10.10
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.10.11.ebuild
+++ b/app-office/qownnotes/qownnotes-19.10.11.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.10.11
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.10.12.ebuild
+++ b/app-office/qownnotes/qownnotes-19.10.12.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.10.12
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.10.13.ebuild
+++ b/app-office/qownnotes/qownnotes-19.10.13.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.10.13
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.10.2.ebuild
+++ b/app-office/qownnotes/qownnotes-19.10.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.10.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.10.3.ebuild
+++ b/app-office/qownnotes/qownnotes-19.10.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.10.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.10.4.ebuild
+++ b/app-office/qownnotes/qownnotes-19.10.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.10.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.10.5.ebuild
+++ b/app-office/qownnotes/qownnotes-19.10.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.10.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.10.6.ebuild
+++ b/app-office/qownnotes/qownnotes-19.10.6.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.10.6
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.10.7.ebuild
+++ b/app-office/qownnotes/qownnotes-19.10.7.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.10.7
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.10.8.ebuild
+++ b/app-office/qownnotes/qownnotes-19.10.8.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.10.8
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.10.9.ebuild
+++ b/app-office/qownnotes/qownnotes-19.10.9.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.10.9
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.11.0.ebuild
+++ b/app-office/qownnotes/qownnotes-19.11.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.11.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.11.1.ebuild
+++ b/app-office/qownnotes/qownnotes-19.11.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.11.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.11.10.ebuild
+++ b/app-office/qownnotes/qownnotes-19.11.10.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.11.10
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.11.11.ebuild
+++ b/app-office/qownnotes/qownnotes-19.11.11.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.11.11
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.11.12.ebuild
+++ b/app-office/qownnotes/qownnotes-19.11.12.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.11.12
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.11.13.ebuild
+++ b/app-office/qownnotes/qownnotes-19.11.13.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.11.13
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.11.14.ebuild
+++ b/app-office/qownnotes/qownnotes-19.11.14.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.11.14
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.11.15.ebuild
+++ b/app-office/qownnotes/qownnotes-19.11.15.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.11.15
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.11.16.ebuild
+++ b/app-office/qownnotes/qownnotes-19.11.16.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.11.16
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.11.17.ebuild
+++ b/app-office/qownnotes/qownnotes-19.11.17.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.11.17
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.11.18.ebuild
+++ b/app-office/qownnotes/qownnotes-19.11.18.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.11.18
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.11.19.ebuild
+++ b/app-office/qownnotes/qownnotes-19.11.19.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.11.19
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.11.2.ebuild
+++ b/app-office/qownnotes/qownnotes-19.11.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.11.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.11.20.ebuild
+++ b/app-office/qownnotes/qownnotes-19.11.20.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.11.20
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.11.21.ebuild
+++ b/app-office/qownnotes/qownnotes-19.11.21.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.11.21
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.11.22.ebuild
+++ b/app-office/qownnotes/qownnotes-19.11.22.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.11.22
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.11.23.ebuild
+++ b/app-office/qownnotes/qownnotes-19.11.23.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.11.23
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.11.3.ebuild
+++ b/app-office/qownnotes/qownnotes-19.11.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.11.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.11.4.ebuild
+++ b/app-office/qownnotes/qownnotes-19.11.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.11.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.11.5.ebuild
+++ b/app-office/qownnotes/qownnotes-19.11.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.11.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.11.6.ebuild
+++ b/app-office/qownnotes/qownnotes-19.11.6.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.11.6
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.11.7.ebuild
+++ b/app-office/qownnotes/qownnotes-19.11.7.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.11.7
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.11.8.ebuild
+++ b/app-office/qownnotes/qownnotes-19.11.8.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.11.8
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.11.9.ebuild
+++ b/app-office/qownnotes/qownnotes-19.11.9.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.11.9
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.12.0.ebuild
+++ b/app-office/qownnotes/qownnotes-19.12.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.12.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.12.1.ebuild
+++ b/app-office/qownnotes/qownnotes-19.12.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.12.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.12.10.ebuild
+++ b/app-office/qownnotes/qownnotes-19.12.10.ebuild
@@ -37,6 +37,7 @@ RDEPEND="${DEPEND}"
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
 	default
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.12.11.ebuild
+++ b/app-office/qownnotes/qownnotes-19.12.11.ebuild
@@ -37,6 +37,7 @@ RDEPEND="${DEPEND}"
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
 	default
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.12.12.ebuild
+++ b/app-office/qownnotes/qownnotes-19.12.12.ebuild
@@ -37,6 +37,7 @@ RDEPEND="${DEPEND}"
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
 	default
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.12.13.ebuild
+++ b/app-office/qownnotes/qownnotes-19.12.13.ebuild
@@ -37,6 +37,7 @@ RDEPEND="${DEPEND}"
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
 	default
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.12.14.ebuild
+++ b/app-office/qownnotes/qownnotes-19.12.14.ebuild
@@ -37,6 +37,7 @@ RDEPEND="${DEPEND}"
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
 	default
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.12.15.ebuild
+++ b/app-office/qownnotes/qownnotes-19.12.15.ebuild
@@ -37,6 +37,7 @@ RDEPEND="${DEPEND}"
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
 	default
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.12.2.ebuild
+++ b/app-office/qownnotes/qownnotes-19.12.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.12.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.12.3.ebuild
+++ b/app-office/qownnotes/qownnotes-19.12.3.ebuild
@@ -37,6 +37,7 @@ RDEPEND="${DEPEND}"
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
 	default
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.12.4.ebuild
+++ b/app-office/qownnotes/qownnotes-19.12.4.ebuild
@@ -37,6 +37,7 @@ RDEPEND="${DEPEND}"
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
 	default
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.12.5.ebuild
+++ b/app-office/qownnotes/qownnotes-19.12.5.ebuild
@@ -37,6 +37,7 @@ RDEPEND="${DEPEND}"
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
 	default
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.12.6.ebuild
+++ b/app-office/qownnotes/qownnotes-19.12.6.ebuild
@@ -37,6 +37,7 @@ RDEPEND="${DEPEND}"
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
 	default
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.12.7.ebuild
+++ b/app-office/qownnotes/qownnotes-19.12.7.ebuild
@@ -37,6 +37,7 @@ RDEPEND="${DEPEND}"
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
 	default
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.12.8.ebuild
+++ b/app-office/qownnotes/qownnotes-19.12.8.ebuild
@@ -37,6 +37,7 @@ RDEPEND="${DEPEND}"
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
 	default
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.12.9.ebuild
+++ b/app-office/qownnotes/qownnotes-19.12.9.ebuild
@@ -37,6 +37,7 @@ RDEPEND="${DEPEND}"
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
 	default
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.2.0.ebuild
+++ b/app-office/qownnotes/qownnotes-19.2.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.2.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.2.1.ebuild
+++ b/app-office/qownnotes/qownnotes-19.2.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.2.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.2.2.ebuild
+++ b/app-office/qownnotes/qownnotes-19.2.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.2.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.2.3.ebuild
+++ b/app-office/qownnotes/qownnotes-19.2.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.2.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.2.4.ebuild
+++ b/app-office/qownnotes/qownnotes-19.2.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.2.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.2.5.ebuild
+++ b/app-office/qownnotes/qownnotes-19.2.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.2.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.3.0.ebuild
+++ b/app-office/qownnotes/qownnotes-19.3.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.3.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.3.1.ebuild
+++ b/app-office/qownnotes/qownnotes-19.3.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.3.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.3.2.ebuild
+++ b/app-office/qownnotes/qownnotes-19.3.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.3.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.3.3.ebuild
+++ b/app-office/qownnotes/qownnotes-19.3.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.3.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.3.4.ebuild
+++ b/app-office/qownnotes/qownnotes-19.3.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.3.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.4.0.ebuild
+++ b/app-office/qownnotes/qownnotes-19.4.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.4.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.4.1.ebuild
+++ b/app-office/qownnotes/qownnotes-19.4.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.4.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.4.2.ebuild
+++ b/app-office/qownnotes/qownnotes-19.4.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.4.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.4.3.ebuild
+++ b/app-office/qownnotes/qownnotes-19.4.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.4.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.4.4.ebuild
+++ b/app-office/qownnotes/qownnotes-19.4.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.4.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.4.5.ebuild
+++ b/app-office/qownnotes/qownnotes-19.4.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.4.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.5.0.ebuild
+++ b/app-office/qownnotes/qownnotes-19.5.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.5.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.5.1.ebuild
+++ b/app-office/qownnotes/qownnotes-19.5.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.5.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.5.2.ebuild
+++ b/app-office/qownnotes/qownnotes-19.5.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.5.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.5.3.ebuild
+++ b/app-office/qownnotes/qownnotes-19.5.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.5.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.5.4.ebuild
+++ b/app-office/qownnotes/qownnotes-19.5.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.5.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.5.5.ebuild
+++ b/app-office/qownnotes/qownnotes-19.5.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.5.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.5.6.ebuild
+++ b/app-office/qownnotes/qownnotes-19.5.6.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.5.6
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.5.7.ebuild
+++ b/app-office/qownnotes/qownnotes-19.5.7.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.5.7
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.6.0.ebuild
+++ b/app-office/qownnotes/qownnotes-19.6.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.6.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.6.1.ebuild
+++ b/app-office/qownnotes/qownnotes-19.6.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.6.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.6.2.ebuild
+++ b/app-office/qownnotes/qownnotes-19.6.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.6.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.6.3.ebuild
+++ b/app-office/qownnotes/qownnotes-19.6.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.6.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.6.4.ebuild
+++ b/app-office/qownnotes/qownnotes-19.6.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.6.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.6.5.ebuild
+++ b/app-office/qownnotes/qownnotes-19.6.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.6.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.6.6.ebuild
+++ b/app-office/qownnotes/qownnotes-19.6.6.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.6.6
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.7.0.ebuild
+++ b/app-office/qownnotes/qownnotes-19.7.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.7.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.7.1.ebuild
+++ b/app-office/qownnotes/qownnotes-19.7.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.7.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.7.10.ebuild
+++ b/app-office/qownnotes/qownnotes-19.7.10.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.7.10
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.7.11.ebuild
+++ b/app-office/qownnotes/qownnotes-19.7.11.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.7.11
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.7.2.ebuild
+++ b/app-office/qownnotes/qownnotes-19.7.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.7.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.7.3.ebuild
+++ b/app-office/qownnotes/qownnotes-19.7.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.7.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.7.4.ebuild
+++ b/app-office/qownnotes/qownnotes-19.7.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.7.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.7.5.ebuild
+++ b/app-office/qownnotes/qownnotes-19.7.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.7.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.7.6.ebuild
+++ b/app-office/qownnotes/qownnotes-19.7.6.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.7.6
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.7.7.ebuild
+++ b/app-office/qownnotes/qownnotes-19.7.7.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.7.7
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.7.8.ebuild
+++ b/app-office/qownnotes/qownnotes-19.7.8.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.7.8
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.7.9.ebuild
+++ b/app-office/qownnotes/qownnotes-19.7.9.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.7.9
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.8.0.ebuild
+++ b/app-office/qownnotes/qownnotes-19.8.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.8.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.8.1.ebuild
+++ b/app-office/qownnotes/qownnotes-19.8.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.8.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.8.2.ebuild
+++ b/app-office/qownnotes/qownnotes-19.8.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.8.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.8.3.ebuild
+++ b/app-office/qownnotes/qownnotes-19.8.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.8.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.8.4.ebuild
+++ b/app-office/qownnotes/qownnotes-19.8.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.8.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.8.5.ebuild
+++ b/app-office/qownnotes/qownnotes-19.8.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.8.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.8.6.ebuild
+++ b/app-office/qownnotes/qownnotes-19.8.6.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.8.6
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.8.7.ebuild
+++ b/app-office/qownnotes/qownnotes-19.8.7.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.8.7
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.8.8.ebuild
+++ b/app-office/qownnotes/qownnotes-19.8.8.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.8.8
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.9.0.ebuild
+++ b/app-office/qownnotes/qownnotes-19.9.0.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.9.0
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.9.1.ebuild
+++ b/app-office/qownnotes/qownnotes-19.9.1.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.9.1
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.9.10.ebuild
+++ b/app-office/qownnotes/qownnotes-19.9.10.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.9.10
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.9.11.ebuild
+++ b/app-office/qownnotes/qownnotes-19.9.11.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.9.11
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.9.12.ebuild
+++ b/app-office/qownnotes/qownnotes-19.9.12.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.9.12
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.9.13.ebuild
+++ b/app-office/qownnotes/qownnotes-19.9.13.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.9.13
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.9.14.ebuild
+++ b/app-office/qownnotes/qownnotes-19.9.14.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.9.14
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.9.15.ebuild
+++ b/app-office/qownnotes/qownnotes-19.9.15.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.9.15
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.9.16.ebuild
+++ b/app-office/qownnotes/qownnotes-19.9.16.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.9.16
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.9.17.ebuild
+++ b/app-office/qownnotes/qownnotes-19.9.17.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.9.17
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.9.18.ebuild
+++ b/app-office/qownnotes/qownnotes-19.9.18.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.9.18
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.9.19.ebuild
+++ b/app-office/qownnotes/qownnotes-19.9.19.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.9.19
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.9.2.ebuild
+++ b/app-office/qownnotes/qownnotes-19.9.2.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.9.2
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.9.20.ebuild
+++ b/app-office/qownnotes/qownnotes-19.9.20.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.9.20
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.9.3.ebuild
+++ b/app-office/qownnotes/qownnotes-19.9.3.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.9.3
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.9.4.ebuild
+++ b/app-office/qownnotes/qownnotes-19.9.4.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.9.4
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.9.5.ebuild
+++ b/app-office/qownnotes/qownnotes-19.9.5.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.9.5
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.9.6.ebuild
+++ b/app-office/qownnotes/qownnotes-19.9.6.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.9.6
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.9.7.ebuild
+++ b/app-office/qownnotes/qownnotes-19.9.7.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.9.7
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.9.8.ebuild
+++ b/app-office/qownnotes/qownnotes-19.9.8.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.9.8
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {

--- a/app-office/qownnotes/qownnotes-19.9.9.ebuild
+++ b/app-office/qownnotes/qownnotes-19.9.9.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes 19.9.9
 #
 
-EAPI=5
+EAPI=7
 
 inherit qmake-utils eutils
 
@@ -36,6 +36,7 @@ RDEPEND="${DEPEND}"
 
 src_prepare() {
 	echo "#define RELEASE \"Gentoo\"" > release.h
+	default
 }
 
 src_compile() {


### PR DESCRIPTION
…ing from portage

Made by applying these 2 commands : 
    sed -i 's/EAPI=5/EAPI=7/' qownnotes-1*.ebuild
    sed -i 's/release.h/release.h\n\tdefault/' qownnotes-1*.ebuild

You might want to remove qownnotes-1.*.ebuild, as they might not build. At least qownnotes-16.04.12-r1.ebuild builds, and some up.