### PR TITLE
Require qtconcurrent(QON bug #2847)

### DIFF
--- a/app-office/qownnotes/qownnotes-21.12.0.ebuild
+++ b/app-office/qownnotes/qownnotes-21.12.0.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-21.12.1.ebuild
+++ b/app-office/qownnotes/qownnotes-21.12.1.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-21.12.2.ebuild
+++ b/app-office/qownnotes/qownnotes-21.12.2.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-21.12.3.ebuild
+++ b/app-office/qownnotes/qownnotes-21.12.3.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-21.12.4.ebuild
+++ b/app-office/qownnotes/qownnotes-21.12.4.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-21.12.5.ebuild
+++ b/app-office/qownnotes/qownnotes-21.12.5.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-21.12.6.ebuild
+++ b/app-office/qownnotes/qownnotes-21.12.6.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-21.12.7.ebuild
+++ b/app-office/qownnotes/qownnotes-21.12.7.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-21.12.8.ebuild
+++ b/app-office/qownnotes/qownnotes-21.12.8.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.1.0.ebuild
+++ b/app-office/qownnotes/qownnotes-22.1.0.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.1.1.ebuild
+++ b/app-office/qownnotes/qownnotes-22.1.1.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.1.10.1.ebuild
+++ b/app-office/qownnotes/qownnotes-22.1.10.1.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.1.10.ebuild
+++ b/app-office/qownnotes/qownnotes-22.1.10.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.1.11.ebuild
+++ b/app-office/qownnotes/qownnotes-22.1.11.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.1.12.ebuild
+++ b/app-office/qownnotes/qownnotes-22.1.12.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.1.2.ebuild
+++ b/app-office/qownnotes/qownnotes-22.1.2.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.1.3.ebuild
+++ b/app-office/qownnotes/qownnotes-22.1.3.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.1.4.ebuild
+++ b/app-office/qownnotes/qownnotes-22.1.4.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.1.5.ebuild
+++ b/app-office/qownnotes/qownnotes-22.1.5.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.1.6.ebuild
+++ b/app-office/qownnotes/qownnotes-22.1.6.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.1.7.ebuild
+++ b/app-office/qownnotes/qownnotes-22.1.7.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.1.8.ebuild
+++ b/app-office/qownnotes/qownnotes-22.1.8.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.1.9.ebuild
+++ b/app-office/qownnotes/qownnotes-22.1.9.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.10.0.ebuild
+++ b/app-office/qownnotes/qownnotes-22.10.0.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.10.1.ebuild
+++ b/app-office/qownnotes/qownnotes-22.10.1.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.10.2.ebuild
+++ b/app-office/qownnotes/qownnotes-22.10.2.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.10.3.ebuild
+++ b/app-office/qownnotes/qownnotes-22.10.3.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.11.0.ebuild
+++ b/app-office/qownnotes/qownnotes-22.11.0.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.11.1.ebuild
+++ b/app-office/qownnotes/qownnotes-22.11.1.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.11.2.ebuild
+++ b/app-office/qownnotes/qownnotes-22.11.2.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.11.3.ebuild
+++ b/app-office/qownnotes/qownnotes-22.11.3.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.11.4.ebuild
+++ b/app-office/qownnotes/qownnotes-22.11.4.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.11.5.ebuild
+++ b/app-office/qownnotes/qownnotes-22.11.5.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.11.6.ebuild
+++ b/app-office/qownnotes/qownnotes-22.11.6.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.11.7.ebuild
+++ b/app-office/qownnotes/qownnotes-22.11.7.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.11.8.ebuild
+++ b/app-office/qownnotes/qownnotes-22.11.8.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.11.9.ebuild
+++ b/app-office/qownnotes/qownnotes-22.11.9.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.12.0.ebuild
+++ b/app-office/qownnotes/qownnotes-22.12.0.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.12.1.ebuild
+++ b/app-office/qownnotes/qownnotes-22.12.1.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.12.2.ebuild
+++ b/app-office/qownnotes/qownnotes-22.12.2.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.12.3.ebuild
+++ b/app-office/qownnotes/qownnotes-22.12.3.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.2.0.ebuild
+++ b/app-office/qownnotes/qownnotes-22.2.0.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.2.1.ebuild
+++ b/app-office/qownnotes/qownnotes-22.2.1.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.2.10.ebuild
+++ b/app-office/qownnotes/qownnotes-22.2.10.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.2.2.ebuild
+++ b/app-office/qownnotes/qownnotes-22.2.2.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.2.3.ebuild
+++ b/app-office/qownnotes/qownnotes-22.2.3.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.2.4.ebuild
+++ b/app-office/qownnotes/qownnotes-22.2.4.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.2.5.ebuild
+++ b/app-office/qownnotes/qownnotes-22.2.5.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.2.6.ebuild
+++ b/app-office/qownnotes/qownnotes-22.2.6.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.2.7.ebuild
+++ b/app-office/qownnotes/qownnotes-22.2.7.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.2.8.ebuild
+++ b/app-office/qownnotes/qownnotes-22.2.8.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.2.9.ebuild
+++ b/app-office/qownnotes/qownnotes-22.2.9.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.3.0.ebuild
+++ b/app-office/qownnotes/qownnotes-22.3.0.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.3.1.ebuild
+++ b/app-office/qownnotes/qownnotes-22.3.1.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.3.2.ebuild
+++ b/app-office/qownnotes/qownnotes-22.3.2.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.3.3.ebuild
+++ b/app-office/qownnotes/qownnotes-22.3.3.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.3.4.ebuild
+++ b/app-office/qownnotes/qownnotes-22.3.4.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.4.0.ebuild
+++ b/app-office/qownnotes/qownnotes-22.4.0.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.4.1.ebuild
+++ b/app-office/qownnotes/qownnotes-22.4.1.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.4.2.ebuild
+++ b/app-office/qownnotes/qownnotes-22.4.2.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.5.0.ebuild
+++ b/app-office/qownnotes/qownnotes-22.5.0.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.5.1.ebuild
+++ b/app-office/qownnotes/qownnotes-22.5.1.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.5.2.ebuild
+++ b/app-office/qownnotes/qownnotes-22.5.2.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.5.3.ebuild
+++ b/app-office/qownnotes/qownnotes-22.5.3.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.6.0.ebuild
+++ b/app-office/qownnotes/qownnotes-22.6.0.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.6.1.ebuild
+++ b/app-office/qownnotes/qownnotes-22.6.1.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.6.2.ebuild
+++ b/app-office/qownnotes/qownnotes-22.6.2.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.7.0.ebuild
+++ b/app-office/qownnotes/qownnotes-22.7.0.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.7.1.ebuild
+++ b/app-office/qownnotes/qownnotes-22.7.1.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.7.2.ebuild
+++ b/app-office/qownnotes/qownnotes-22.7.2.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.7.3.ebuild
+++ b/app-office/qownnotes/qownnotes-22.7.3.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.7.4.ebuild
+++ b/app-office/qownnotes/qownnotes-22.7.4.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.7.5.ebuild
+++ b/app-office/qownnotes/qownnotes-22.7.5.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.7.6.ebuild
+++ b/app-office/qownnotes/qownnotes-22.7.6.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.8.0.ebuild
+++ b/app-office/qownnotes/qownnotes-22.8.0.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.8.1.ebuild
+++ b/app-office/qownnotes/qownnotes-22.8.1.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.8.2.ebuild
+++ b/app-office/qownnotes/qownnotes-22.8.2.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.8.3.ebuild
+++ b/app-office/qownnotes/qownnotes-22.8.3.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.8.4.ebuild
+++ b/app-office/qownnotes/qownnotes-22.8.4.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.9.0.ebuild
+++ b/app-office/qownnotes/qownnotes-22.9.0.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.9.1.ebuild
+++ b/app-office/qownnotes/qownnotes-22.9.1.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-22.9.2.ebuild
+++ b/app-office/qownnotes/qownnotes-22.9.2.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.1.0.ebuild
+++ b/app-office/qownnotes/qownnotes-23.1.0.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.1.1.ebuild
+++ b/app-office/qownnotes/qownnotes-23.1.1.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.1.2.ebuild
+++ b/app-office/qownnotes/qownnotes-23.1.2.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.1.3.ebuild
+++ b/app-office/qownnotes/qownnotes-23.1.3.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.1.4.ebuild
+++ b/app-office/qownnotes/qownnotes-23.1.4.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.1.5.ebuild
+++ b/app-office/qownnotes/qownnotes-23.1.5.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.1.6.ebuild
+++ b/app-office/qownnotes/qownnotes-23.1.6.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.2.0.ebuild
+++ b/app-office/qownnotes/qownnotes-23.2.0.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.2.1.ebuild
+++ b/app-office/qownnotes/qownnotes-23.2.1.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.2.2.ebuild
+++ b/app-office/qownnotes/qownnotes-23.2.2.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.2.3.ebuild
+++ b/app-office/qownnotes/qownnotes-23.2.3.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.2.4.ebuild
+++ b/app-office/qownnotes/qownnotes-23.2.4.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.2.5.ebuild
+++ b/app-office/qownnotes/qownnotes-23.2.5.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.3.0.ebuild
+++ b/app-office/qownnotes/qownnotes-23.3.0.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.3.1.ebuild
+++ b/app-office/qownnotes/qownnotes-23.3.1.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.3.2.ebuild
+++ b/app-office/qownnotes/qownnotes-23.3.2.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.3.3.ebuild
+++ b/app-office/qownnotes/qownnotes-23.3.3.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.3.4.ebuild
+++ b/app-office/qownnotes/qownnotes-23.3.4.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.3.6.ebuild
+++ b/app-office/qownnotes/qownnotes-23.3.6.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.3.7.ebuild
+++ b/app-office/qownnotes/qownnotes-23.3.7.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.3.8.ebuild
+++ b/app-office/qownnotes/qownnotes-23.3.8.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.4.0.ebuild
+++ b/app-office/qownnotes/qownnotes-23.4.0.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.4.1.ebuild
+++ b/app-office/qownnotes/qownnotes-23.4.1.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.4.2.ebuild
+++ b/app-office/qownnotes/qownnotes-23.4.2.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.4.3.ebuild
+++ b/app-office/qownnotes/qownnotes-23.4.3.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.4.4.ebuild
+++ b/app-office/qownnotes/qownnotes-23.4.4.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.4.5.ebuild
+++ b/app-office/qownnotes/qownnotes-23.4.5.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.4.6.ebuild
+++ b/app-office/qownnotes/qownnotes-23.4.6.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.4.7.ebuild
+++ b/app-office/qownnotes/qownnotes-23.4.7.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.5.0.ebuild
+++ b/app-office/qownnotes/qownnotes-23.5.0.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.5.1.ebuild
+++ b/app-office/qownnotes/qownnotes-23.5.1.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.5.2.ebuild
+++ b/app-office/qownnotes/qownnotes-23.5.2.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.5.3.ebuild
+++ b/app-office/qownnotes/qownnotes-23.5.3.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.6.0.ebuild
+++ b/app-office/qownnotes/qownnotes-23.6.0.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.6.1.ebuild
+++ b/app-office/qownnotes/qownnotes-23.6.1.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.6.2.ebuild
+++ b/app-office/qownnotes/qownnotes-23.6.2.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.6.3.ebuild
+++ b/app-office/qownnotes/qownnotes-23.6.3.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.6.4.ebuild
+++ b/app-office/qownnotes/qownnotes-23.6.4.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.6.5.ebuild
+++ b/app-office/qownnotes/qownnotes-23.6.5.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.6.6.ebuild
+++ b/app-office/qownnotes/qownnotes-23.6.6.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.7.1.ebuild
+++ b/app-office/qownnotes/qownnotes-23.7.1.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.7.2.ebuild
+++ b/app-office/qownnotes/qownnotes-23.7.2.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.7.3.ebuild
+++ b/app-office/qownnotes/qownnotes-23.7.3.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.8.0.ebuild
+++ b/app-office/qownnotes/qownnotes-23.8.0.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.8.1.ebuild
+++ b/app-office/qownnotes/qownnotes-23.8.1.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.8.2.ebuild
+++ b/app-office/qownnotes/qownnotes-23.8.2.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.9.0.ebuild
+++ b/app-office/qownnotes/qownnotes-23.9.0.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.9.1.ebuild
+++ b/app-office/qownnotes/qownnotes-23.9.1.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.9.2.ebuild
+++ b/app-office/qownnotes/qownnotes-23.9.2.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.9.3.ebuild
+++ b/app-office/qownnotes/qownnotes-23.9.3.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.9.4.ebuild
+++ b/app-office/qownnotes/qownnotes-23.9.4.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5

--- a/app-office/qownnotes/qownnotes-23.9.5.ebuild
+++ b/app-office/qownnotes/qownnotes-23.9.5.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5


### PR DESCRIPTION
Sister PR to [QOwnNotes#2857](https://github.com/pbek/QOwnNotes/pull/2857), resolving the requirement for `dev-qt/qtconcurrent:5`. The release version that added concurrency requirement is older than all versions in this repo, so every single one needed to be updated.